### PR TITLE
Prevent version increment during integration runs.

### DIFF
--- a/version_increment_pre.py
+++ b/version_increment_pre.py
@@ -29,6 +29,10 @@ VERSION_HEADER = 'Version.h'
 VERSION_PREFIX = '0.1.'
 VERSION_PATCH_NUMBER = 0
 
+if env.IsIntegrationDump():
+   # stop the current script execution
+   Return()
+
 if not os.path.exists(".version_no_increment"):
     try:
         with open(VERSION_FILE) as FILE:


### PR DESCRIPTION
From https://docs.platformio.org/en/latest/scripting/launch_types.html

> PlatformIO includes a service stage during runtime where it re-executes extra scripts to gather integration information intended for IDE plugins. If you want your scripts to run exclusively for the “build” target, include the following hook at the beginning of your script: